### PR TITLE
Feature/torch img

### DIFF
--- a/demo_imgs.py
+++ b/demo_imgs.py
@@ -58,17 +58,15 @@ class DisparityCalculator:
         self.output_directory.mkdir(exist_ok=True)
 
     def calc_disparity(self, leftname, rightname):
-        image1 = load_image(leftname)
-        image2 = load_image(rightname)
+        torch_image1 = load_image(leftname)
+        torch_image2 = load_image(rightname)
 
-        padder = InputPadder(image1.shape, divis_by=32)
-        image1, image2 = padder.pad(image1, image2)
+        padder = InputPadder(torch_image1.shape, divis_by=32)
+        torch_image1, torch_image2 = padder.pad(torch_image1, torch_image2)
 
-        disp = self.model(image1, image2, iters=args.valid_iters, test_mode=True)
+        disp = self.model(torch_image1, torch_image2, iters=args.valid_iters, test_mode=True)
         disp = disp.cpu().numpy()
         disp = padder.unpad(disp)
-        file_stem = leftname.split("/")[-2]
-        filename = self.output_directory / f"{file_stem}.png"
         disparity = disp.squeeze()
         return disparity
 

--- a/demo_imgs.py
+++ b/demo_imgs.py
@@ -57,7 +57,7 @@ class DisparityCalculator:
         self.output_directory = Path(self.args.output_directory)
         self.output_directory.mkdir(exist_ok=True)
 
-    def calc_disparity(self, leftname, rightname):
+    def calc_disparity_name(self, leftname, rightname):
         torch_image1 = load_image(leftname)
         torch_image2 = load_image(rightname)
 
@@ -82,7 +82,7 @@ def demo(args):
         print(f"Found {len(left_images)} images. Saving files to {output_directory}/")
 
         for imfile1, imfile2 in tqdm(list(zip(left_images, right_images))):
-            disparity = disparity_calculator.calc_disparity(imfile1, imfile2)
+            disparity = disparity_calculator.calc_disparity_name(imfile1, imfile2)
             file_stem = imfile1.split("/")[-2]
             filename = output_directory / f"{file_stem}.png"
 

--- a/demo_imgs.py
+++ b/demo_imgs.py
@@ -61,9 +61,11 @@ class DisparityCalculator:
         torch_image1 = load_image(leftname)
         torch_image2 = load_image(rightname)
 
+        return self.calc_by_torch_image(torch_image1, torch_image2)
+
+    def calc_by_torch_image(self, torch_image1, torch_image2):
         padder = InputPadder(torch_image1.shape, divis_by=32)
         torch_image1, torch_image2 = padder.pad(torch_image1, torch_image2)
-
         disp = self.model(torch_image1, torch_image2, iters=args.valid_iters, test_mode=True)
         disp = disp.cpu().numpy()
         disp = padder.unpad(disp)

--- a/demo_imgs.py
+++ b/demo_imgs.py
@@ -53,9 +53,10 @@ class DisparityCalculator:
 
         self.model = self.model.module
         self.model.to(DEVICE)
+        
         self.model.eval()
 
-    def calc_disparity_name(self, leftname, rightname) -> np.ndarray:
+    def calc_by_name(self, leftname, rightname) -> np.ndarray:
         torch_image1 = load_image(leftname)
         torch_image2 = load_image(rightname)
         return self.calc_by_torch_image(torch_image1, torch_image2)
@@ -86,7 +87,7 @@ def demo(args):
         print(f"Found {len(left_images)} images. Saving files to {output_directory}/")
 
         for imfile1, imfile2 in tqdm(list(zip(left_images, right_images))):
-            disparity = disparity_calculator.calc_disparity_name(imfile1, imfile2)
+            disparity = disparity_calculator.calc_by_name(imfile1, imfile2)
             file_stem = imfile1.split("/")[-2]
             filename = output_directory / f"{file_stem}.png"
 

--- a/demo_imgs.py
+++ b/demo_imgs.py
@@ -1,5 +1,6 @@
-import sys
-
+"""
+sample script for IGEV Stereo
+"""
 DEVICE = "cuda"
 import os
 
@@ -54,12 +55,12 @@ class DisparityCalculator:
         self.model.to(DEVICE)
         self.model.eval()
 
-    def calc_disparity_name(self, leftname, rightname):
+    def calc_disparity_name(self, leftname, rightname) -> np.ndarray:
         torch_image1 = load_image(leftname)
         torch_image2 = load_image(rightname)
         return self.calc_by_torch_image(torch_image1, torch_image2)
 
-    def calc_by_torch_image(self, torch_image1, torch_image2):
+    def calc_by_torch_image(self, torch_image1, torch_image2) -> np.ndarray:
         padder = InputPadder(torch_image1.shape, divis_by=32)
         torch_image1, torch_image2 = padder.pad(torch_image1, torch_image2)
         disp = self.model(torch_image1, torch_image2, iters=args.valid_iters, test_mode=True)


### PR DESCRIPTION
# why
It's strange that the disparity calculation has the output directory as a data member.
There is still no way to use image data as an argument to the disparity calculation.
# what
Changed data members
Changed method names and added methods
# Verification status
The operation of demo_imgs.py has been confirmed.