### PR TITLE
interactive disparity is available with zed2i as usb camera

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,8 @@ python3 demo_imgs.py --restore_ckpt ./stereoigev/models/sceneflow.pth -l test/te
 - You can see example in demo_imgs.py
 ### Optional: ZED2i 
 ```commandline
-$ usage: usb_cam.py [-h] [--calc_disparity] video_num
+$ python3 usb_cam.py -h
+usage: usb_cam.py [-h] [--calc_disparity] video_num
 
 disparity tool for ZED2i camera as usb camera
 

--- a/README.md
+++ b/README.md
@@ -44,13 +44,18 @@ python3 demo_imgs.py --restore_ckpt ./stereoigev/models/sceneflow.pth -l test/te
 - You can see example in demo_imgs.py
 ### Optional: ZED2i 
 ```commandline
-$ usage: usb_cam.py [-h] [--calc_disparity]
+$ usage: usb_cam.py [-h] [--calc_disparity] video_num
+
+disparity tool for ZED2i camera as usb camera
+
+positional arguments:
+  video_num         number in /dev/video
 
 optional arguments:
   -h, --help        show this help message and exit
   --calc_disparity  calc disparity
 
-$ python3 usb_cam.py --calc_disparity 
+$ python3 usb_cam.py --calc_disparity 0
 ```
 ## npy file viewer and helper script for zed camera(StereoLabs)
 - https://github.com/katsunori-waragai/disparity-view

--- a/README.md
+++ b/README.md
@@ -42,7 +42,16 @@ python3 demo_imgs.py --restore_ckpt ./stereoigev/models/sceneflow.pth -l test/te
   - stereoigev.DisparityCalculator
   - stereoigev.as_torch_img
 - You can see example in demo_imgs.py
+### Optional: ZED2i 
+```commandline
+$ usage: usb_cam.py [-h] [--calc_disparity]
 
+optional arguments:
+  -h, --help        show this help message and exit
+  --calc_disparity  calc disparity
+
+$ python3 usb_cam.py --calc_disparity 
+```
 ## npy file viewer and helper script for zed camera(StereoLabs)
 - https://github.com/katsunori-waragai/disparity-view
 - pip install disparity-viewer

--- a/usb_cam.py
+++ b/usb_cam.py
@@ -1,0 +1,20 @@
+import cv2
+
+# import stereoigev
+#
+# disparity_calculator = stereoigev.DisparityCalculator(args=args)
+
+cap = cv2.VideoCapture(0)
+while True:
+    _, frame = cap.read()
+    H, W = frame.shape[:2]
+    half_W = W // 2
+    left = frame[:, :half_W, :]
+    right = frame[:, half_W:, :]
+
+    cv2.imshow("left", left)
+    # disparity = disparity_calculator.calc_by_bgr(left.copy(), right.copy())
+    # disp = np.round(disparity * 256).astype(np.uint16)
+    # colored = cv2.applyColorMap(cv2.convertScaleAbs(disp, alpha=0.01), cv2.COLORMAP_JET)
+    # cv2.imshow("IGEV", colored)
+    key = cv2.waitKey(100)

--- a/usb_cam.py
+++ b/usb_cam.py
@@ -42,17 +42,19 @@ def default_args():
 
 
 if __name__ == "__main__":
-    parser = argparse.ArgumentParser()
+    parser = argparse.ArgumentParser(description="disparity tool for ZED2i camera as usb camera")
     parser.add_argument("--calc_disparity", action="store_true", help="calc disparity")
+    parser.add_argument("video_num",  help="number in /dev/video")
     real_args = parser.parse_args()
 
     calc_disparity = real_args.calc_disparity
+    video_num = int(real_args.video_num)
 
     if calc_disparity:
         args = default_args()
         disparity_calculator = stereoigev.DisparityCalculator(args=args)
 
-    cap = cv2.VideoCapture(0)
+    cap = cv2.VideoCapture(video_num)
     with torch.no_grad():
         while True:
             _, frame = cap.read()

--- a/usb_cam.py
+++ b/usb_cam.py
@@ -1,10 +1,19 @@
+"""
+Script for capture as usb camera and estimate disparity.
+
+Fatal Error:
+    This script cause Jetson freeze.
+    apt install for some library may need.
+    ex gstreamer.
+"""
 import cv2
 import numpy as np
+import argparse
 
 import stereoigev
 
 def default_args():
-    args = Namespace(
+    args = argparse.Namespace(
         corr_implementation="reg",
         corr_levels=2,
         corr_radius=4,
@@ -25,10 +34,15 @@ def default_args():
     return args
 
 if __name__ == "__main__":
-    from argparse import Namespace
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--calc_disparity", action="store_true", help="calc disparity")
+    real_args = parser.parse_args()
 
-    args = default_args()
-    disparity_calculator = stereoigev.DisparityCalculator(args=args)
+    calc_disparity = real_args.calc_disparity
+
+    if calc_disparity:
+        args = default_args()
+        disparity_calculator = stereoigev.DisparityCalculator(args=args)
 
     cap = cv2.VideoCapture(0)
     while True:
@@ -39,10 +53,12 @@ if __name__ == "__main__":
         right = frame[:, half_W:, :]
 
         cv2.imshow("left", left)
-        disparity = disparity_calculator.calc_by_bgr(left.copy(), right.copy())
-        disp = np.round(disparity * 256).astype(np.uint16)
-        colored = cv2.applyColorMap(cv2.convertScaleAbs(disp, alpha=0.01), cv2.COLORMAP_JET)
-        cv2.imshow("IGEV", colored)
+
+        if calc_disparity:
+            disparity = disparity_calculator.calc_by_bgr(left.copy(), right.copy())
+            disp = np.round(disparity * 256).astype(np.uint16)
+            colored = cv2.applyColorMap(cv2.convertScaleAbs(disp, alpha=0.01), cv2.COLORMAP_JET)
+            cv2.imshow("IGEV", colored)
         key = cv2.waitKey(100)
         if key == ord("q"):
             exit()

--- a/usb_cam.py
+++ b/usb_cam.py
@@ -1,11 +1,35 @@
 import cv2
+import numpy as np
 
-# import stereoigev
-#
+import stereoigev
+
+def default_args():
+    args = Namespace(
+        corr_implementation="reg",
+        corr_levels=2,
+        corr_radius=4,
+        hidden_dims=[128, 128, 128],
+        # left_imgs="test-imgs/left/left*.png",
+        max_disp=192,
+        mixed_precision=False,
+        n_downsample=2,
+        n_gru_layers=3,
+        output_directory="./test-output/",
+        restore_ckpt="./stereoigev/models/sceneflow.pth",
+        # right_imgs="test-imgs/right/right*.png",
+        save_numpy=True,
+        shared_backbone=False,
+        slow_fast_gru=False,
+        valid_iters=32,
+    )
+    return args
 
 if __name__ == "__main__":
-    # disparity_calculator = stereoigev.DisparityCalculator(args=args)
-    
+    from argparse import Namespace
+
+    args = default_args()
+    disparity_calculator = stereoigev.DisparityCalculator(args=args)
+
     cap = cv2.VideoCapture(0)
     while True:
         _, frame = cap.read()
@@ -15,10 +39,10 @@ if __name__ == "__main__":
         right = frame[:, half_W:, :]
 
         cv2.imshow("left", left)
-        # disparity = disparity_calculator.calc_by_bgr(left.copy(), right.copy())
-        # disp = np.round(disparity * 256).astype(np.uint16)
-        # colored = cv2.applyColorMap(cv2.convertScaleAbs(disp, alpha=0.01), cv2.COLORMAP_JET)
-        # cv2.imshow("IGEV", colored)
+        disparity = disparity_calculator.calc_by_bgr(left.copy(), right.copy())
+        disp = np.round(disparity * 256).astype(np.uint16)
+        colored = cv2.applyColorMap(cv2.convertScaleAbs(disp, alpha=0.01), cv2.COLORMAP_JET)
+        cv2.imshow("IGEV", colored)
         key = cv2.waitKey(100)
         if key == ord("q"):
             exit()

--- a/usb_cam.py
+++ b/usb_cam.py
@@ -51,23 +51,24 @@ if __name__ == "__main__":
         disparity_calculator = stereoigev.DisparityCalculator(args=args)
 
     cap = cv2.VideoCapture(0)
-    while True:
-        _, frame = cap.read()
-        H, W = frame.shape[:2]
-        H4, W4 = H // 4, W // 4
-        frame = cv2.resize(frame, (W4, H4), interpolation=cv2.INTER_AREA)
-        H, W = frame.shape[:2]
-        half_W = W // 2
-        left = frame[:, :half_W, :]
-        right = frame[:, half_W:, :]
+    with torch.no_grad():
+        while True:
+            _, frame = cap.read()
+            H, W = frame.shape[:2]
+            H4, W4 = H // 4, W // 4
+            frame = cv2.resize(frame, (W4, H4), interpolation=cv2.INTER_AREA)
+            H, W = frame.shape[:2]
+            half_W = W // 2
+            left = frame[:, :half_W, :]
+            right = frame[:, half_W:, :]
 
-        cv2.imshow("left", left)
+            cv2.imshow("left", left)
 
-        if calc_disparity:
-            disparity = disparity_calculator.calc_by_bgr(left.copy(), right.copy())
-            disp = np.round(disparity * 256).astype(np.uint16)
-            colored = cv2.applyColorMap(cv2.convertScaleAbs(disp, alpha=0.01), cv2.COLORMAP_JET)
-            cv2.imshow("IGEV", colored)
-        key = cv2.waitKey(100)
-        if key == ord("q"):
-            exit()
+            if calc_disparity:
+                disparity = disparity_calculator.calc_by_bgr(left.copy(), right.copy())
+                disp = np.round(disparity * 256).astype(np.uint16)
+                colored = cv2.applyColorMap(cv2.convertScaleAbs(disp, alpha=0.01), cv2.COLORMAP_JET)
+                cv2.imshow("IGEV", colored)
+            key = cv2.waitKey(100)
+            if key == ord("q"):
+                exit()

--- a/usb_cam.py
+++ b/usb_cam.py
@@ -48,6 +48,9 @@ if __name__ == "__main__":
     while True:
         _, frame = cap.read()
         H, W = frame.shape[:2]
+        H4, W4 = H // 4, W // 4
+        frame = cv2.resize(frame, (W4, H4), interpolation=cv2.INTER_AREA)
+        H, W = frame.shape[:2]
         half_W = W // 2
         left = frame[:, :half_W, :]
         right = frame[:, half_W:, :]

--- a/usb_cam.py
+++ b/usb_cam.py
@@ -10,9 +10,11 @@ Even if you use image capture only and no disparity calculation,
 GPU usage in jtop command increases.
 """
 
+import argparse
+
 import cv2
 import numpy as np
-import argparse
+import torch
 
 import stereoigev
 
@@ -41,7 +43,7 @@ def default_args():
 
 if __name__ == "__main__":
     parser = argparse.ArgumentParser()
-    parser.add_argument("--calc_disparity", action="store_true", help="calc disparity (buggy: may freeze)")
+    parser.add_argument("--calc_disparity", action="store_true", help="calc disparity")
     real_args = parser.parse_args()
 
     calc_disparity = real_args.calc_disparity

--- a/usb_cam.py
+++ b/usb_cam.py
@@ -5,12 +5,17 @@ Fatal Error:
     This script cause Jetson freeze.
     apt install for some library may need.
     ex gstreamer.
+
+Even if you use image capture only and no disparity calculation,
+GPU usage in jtop command increases.
 """
+
 import cv2
 import numpy as np
 import argparse
 
 import stereoigev
+
 
 def default_args():
     args = argparse.Namespace(
@@ -33,9 +38,10 @@ def default_args():
     )
     return args
 
+
 if __name__ == "__main__":
     parser = argparse.ArgumentParser()
-    parser.add_argument("--calc_disparity", action="store_true", help="calc disparity")
+    parser.add_argument("--calc_disparity", action="store_true", help="calc disparity (buggy: may freeze)")
     real_args = parser.parse_args()
 
     calc_disparity = real_args.calc_disparity

--- a/usb_cam.py
+++ b/usb_cam.py
@@ -2,19 +2,23 @@ import cv2
 
 # import stereoigev
 #
-# disparity_calculator = stereoigev.DisparityCalculator(args=args)
 
-cap = cv2.VideoCapture(0)
-while True:
-    _, frame = cap.read()
-    H, W = frame.shape[:2]
-    half_W = W // 2
-    left = frame[:, :half_W, :]
-    right = frame[:, half_W:, :]
+if __name__ == "__main__":
+    # disparity_calculator = stereoigev.DisparityCalculator(args=args)
+    
+    cap = cv2.VideoCapture(0)
+    while True:
+        _, frame = cap.read()
+        H, W = frame.shape[:2]
+        half_W = W // 2
+        left = frame[:, :half_W, :]
+        right = frame[:, half_W:, :]
 
-    cv2.imshow("left", left)
-    # disparity = disparity_calculator.calc_by_bgr(left.copy(), right.copy())
-    # disp = np.round(disparity * 256).astype(np.uint16)
-    # colored = cv2.applyColorMap(cv2.convertScaleAbs(disp, alpha=0.01), cv2.COLORMAP_JET)
-    # cv2.imshow("IGEV", colored)
-    key = cv2.waitKey(100)
+        cv2.imshow("left", left)
+        # disparity = disparity_calculator.calc_by_bgr(left.copy(), right.copy())
+        # disp = np.round(disparity * 256).astype(np.uint16)
+        # colored = cv2.applyColorMap(cv2.convertScaleAbs(disp, alpha=0.01), cv2.COLORMAP_JET)
+        # cv2.imshow("IGEV", colored)
+        key = cv2.waitKey(100)
+        if key == ord("q"):
+            exit()


### PR DESCRIPTION
# why
- want interactive use with stereo camera.
# what
- added script
usb_cam.py

## usage
```
usage: usb_cam.py [-h] [--calc_disparity] video_num
disparity tool for ZED2i camera as usb camera
positional arguments:
  video_num         number in /dev/video
optional arguments:
  -h, --help        show this help message and exit
  --calc_disparity  calc disparity
```