### PR TITLE
show left and right

### DIFF
--- a/usb_cam.py
+++ b/usb_cam.py
@@ -62,7 +62,7 @@ if __name__ == "__main__":
             left = frame[:, :half_W, :]
             right = frame[:, half_W:, :]
 
-            cv2.imshow("left", left)
+            cv2.imshow("left and right", frame)
 
             if calc_disparity:
                 disparity = disparity_calculator.calc_by_bgr(left.copy(), right.copy())


### PR DESCRIPTION
# WHY
- It is difficult to confirm performance when only the LEFT image is displayed.
I- t is important to check that the corresponding area is shown in the RIGHT image.
# WHAT
- usb_cam.py now shows both left and right images.