### PR TITLE
Feature/show reproject

### DIFF
--- a/usb_cam.py
+++ b/usb_cam.py
@@ -40,6 +40,8 @@ def resize_image(frame: np.ndarray) -> np.ndarray:
 
 if __name__ == "__main__":
     import disparity_view
+    from disparity_view.util import dummy_camera_matrix
+
     parser = argparse.ArgumentParser(description="disparity tool for ZED2i camera as usb camera")
     parser.add_argument("--calc_disparity", action="store_true", help="calc disparity")
     parser.add_argument("--normal", action="store_true", help="normal map")
@@ -82,7 +84,6 @@ if __name__ == "__main__":
                     cv2.imshow("normal", normal_bgr)
 
                 if reproject:
-                    from disparity_view.util import dummy_camera_matrix
                     camera_matrix = dummy_camera_matrix(left.shape)
                     baseline = 120.0
                     tvec = np.array((-baseline, 0.0, 0.0))

--- a/usb_cam.py
+++ b/usb_cam.py
@@ -43,11 +43,13 @@ if __name__ == "__main__":
     parser = argparse.ArgumentParser(description="disparity tool for ZED2i camera as usb camera")
     parser.add_argument("--calc_disparity", action="store_true", help="calc disparity")
     parser.add_argument("--normal", action="store_true", help="normal map")
+    parser.add_argument("--reproject", action="store_true", help="reproject to 2D")
     parser.add_argument("video_num", help="number in /dev/video")
     real_args = parser.parse_args()
 
     calc_disparity = real_args.calc_disparity
     normal =  real_args.normal
+    reproject = real_args.normal.reproject
     video_num = int(real_args.video_num)
 
     if calc_disparity:
@@ -79,8 +81,8 @@ if __name__ == "__main__":
                     normal_bgr = converter.convert(disp)
                     cv2.imshow("normal", normal_bgr)
 
-                if 1:
-                    from disparity_view import dummy_camera_matrix
+                if reproject:
+                    from disparity_view.util import dummy_camera_matrix
                     camera_matrix = dummy_camera_matrix(left.shape)
                     baseline = 120.0
                     tvec = np.array((-baseline, 0.0, 0.0))

--- a/usb_cam.py
+++ b/usb_cam.py
@@ -51,7 +51,7 @@ if __name__ == "__main__":
 
     calc_disparity = real_args.calc_disparity
     normal = real_args.normal
-    reproject = real_args.normal.reproject
+    reproject = real_args.reproject
     video_num = int(real_args.video_num)
 
     if calc_disparity:

--- a/usb_cam.py
+++ b/usb_cam.py
@@ -78,6 +78,15 @@ if __name__ == "__main__":
                 if normal:
                     normal_bgr = converter.convert(disp)
                     cv2.imshow("normal", normal_bgr)
+
+                if 1:
+                    from disparity_view import dummy_camera_matrix
+                    camera_matrix = dummy_camera_matrix(left.shape)
+                    baseline = 120.0
+                    tvec = np.array((-baseline, 0.0, 0.0))
+                    reprojected_image = disparity_view.reproject_from_left_and_disparity(left, disparity,
+                                                                                         camera_matrix, baseline=baseline, tvec=tvec)
+                    cv2.imshow("reprojected", reprojected_image)
             key = cv2.waitKey(100)
             if key == ord("q"):
                 exit()

--- a/usb_cam.py
+++ b/usb_cam.py
@@ -50,7 +50,7 @@ if __name__ == "__main__":
     real_args = parser.parse_args()
 
     calc_disparity = real_args.calc_disparity
-    normal =  real_args.normal
+    normal = real_args.normal
     reproject = real_args.normal.reproject
     video_num = int(real_args.video_num)
 
@@ -87,8 +87,9 @@ if __name__ == "__main__":
                     camera_matrix = dummy_camera_matrix(left.shape)
                     baseline = 120.0
                     tvec = np.array((-baseline, 0.0, 0.0))
-                    reprojected_image = disparity_view.reproject_from_left_and_disparity(left, disparity,
-                                                                                         camera_matrix, baseline=baseline, tvec=tvec)
+                    reprojected_image = disparity_view.reproject_from_left_and_disparity(
+                        left, disparity, camera_matrix, baseline=baseline, tvec=tvec
+                    )
                     cv2.imshow("reprojected", reprojected_image)
             key = cv2.waitKey(100)
             if key == ord("q"):


### PR DESCRIPTION
# why
- 算出した視差画像の妥当性が検証しにくい。
-  再投影画像を使って、視差・深度・点群の品質を目視で確認したい。
# what
- 視差画像と左画像を元に作った点群を再投影するオプションを追加した。
- その画像を見ることで、解釈結果の妥当性を目視確認しやすくする。
- usb_cam.py に --reproject オプションを付けた。
![reprojected](https://github.com/user-attachments/assets/c3bc7641-647c-47a6-b015-bdc91c27fa15)


